### PR TITLE
added new method for updating resource headers

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -203,6 +203,21 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
     }
 
     @Override
+    public synchronized void writeHeaders(final ResourceHeaders headers) {
+        enforceOpen();
+
+        final var paths = resolvePersistencePaths(headers);
+
+        final var headerPath = encode(paths.getHeaderFilePath());
+        final var headerDst = createStagingPath(headerPath);
+
+        deletePaths.remove(headerPath);
+
+        writeHeaders(headers, headerDst);
+        touchRelatedResources(headers);
+    }
+
+    @Override
     public synchronized void deleteContentFile(final ResourceHeaders headers) {
         enforceOpen();
 

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -52,6 +52,13 @@ public interface OcflObjectSession extends AutoCloseable {
     ResourceHeaders writeResource(final ResourceHeaders headers, final InputStream content);
 
     /**
+     * Writes the resources headers to the session.
+     *
+     * @param headers the headers to write
+     */
+    void writeHeaders(final ResourceHeaders headers);
+
+    /**
      * Deletes a content file from the session, and updates the associated headers. If the resource was added in
      * the current session, then its headers are also deleted and it is as if the resource never existed.
      *

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -175,6 +175,36 @@ public class DefaultOcflObjectSessionTest {
     }
 
     @Test
+    public void updateResourceHeaders() {
+        final var resourceId = "info:fedora/foo/bar";
+
+        final var session1 = sessionFactory.newSession(resourceId);
+        final var content1 = atomicBinary(resourceId, "info:fedora/foo", "Test");
+
+        write(session1, content1);
+        session1.commit();
+
+        final var session2 = sessionFactory.newSession(resourceId);
+
+        final var timestamp = Instant.now().plusSeconds(60);
+        final var state = "new-state-token";
+
+        final var existingHeaders = session2.readHeaders(resourceId);
+        final var updatedHeaders = ResourceHeaders.builder(existingHeaders)
+                .withLastModifiedDate(timestamp)
+                .withStateToken(state)
+                .build();
+
+        session2.writeHeaders(updatedHeaders);
+
+        assertEquals(updatedHeaders, session2.readHeaders(resourceId));
+
+        session2.commit();
+
+        assertEquals(updatedHeaders, session2.readHeaders(resourceId));
+    }
+
+    @Test
     public void writeNewAtomicRdfResource() {
         final var resourceId = "info:fedora/foo/bar";
         final var session = sessionFactory.newSession(resourceId);

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -198,6 +198,7 @@ public class DefaultOcflObjectSessionTest {
         session2.writeHeaders(updatedHeaders);
 
         assertEquals(updatedHeaders, session2.readHeaders(resourceId));
+        assertEquals(existingHeaders, sessionFactory.newSession(resourceId).readHeaders(resourceId));
 
         session2.commit();
 


### PR DESCRIPTION
Adds a method for writing resource headers. This is needed for https://jira.lyrasis.org/browse/FCREPO-3465