### PR TITLE
added session rollback

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -462,7 +462,7 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
     @Override
     public synchronized void rollback() {
         if (closed && newVersionNum != null) {
-            if (commitType == CommitType.UNVERSIONED || hadMutableHeadBeforeCommit) {
+            if (hadMutableHeadBeforeCommit) {
                 throw new IllegalStateException(String.format(
                         "Cannot rollback changes to object %s because manual versioning was used on this object.",
                         ocflObjectId));

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -470,7 +470,9 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
 
             LOG.info("Rolling back {} version {}", ocflObjectId, newVersionNum);
 
-            if (VersionNum.V1.equals(newVersionNum)) {
+            if (VersionNum.V1.equals(newVersionNum) ||
+                    (VersionNum.fromInt(2).equals(newVersionNum) && ocflRepo.hasStagedChanges(ocflObjectId))) {
+                // Purge the object if it only has one version or if it is a newly created object with a mutable head
                 ocflRepo.purgeObject(ocflObjectId);
             } else {
                 ocflRepo.rollbackToVersion(ObjectVersionId.version(ocflObjectId, newVersionNum.previousVersionNum()));

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -177,6 +177,15 @@ public interface OcflObjectSession extends AutoCloseable {
     void abort();
 
     /**
+     * Rolls back an already committed session, permanently removing the OCFL object version that was created by the
+     * session. Sessions may only be rolled back when auto-versioning in enabled. Calling this method on a session
+     * that has not yet been committed does nothing.
+     *
+     * @throws IllegalStateException if the session cannot be rolled back because manual versioning was used
+     */
+    void rollback();
+
+    /**
      * @return true if the session is still open
      */
     boolean isOpen();

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -359,7 +359,7 @@ public class DefaultOcflObjectSessionTest {
         assertResourceContent("test", content, session.readContent(resourceId));
 
         session.rollback();
-        
+
         expectResourceNotFound(resourceId, session);
     }
 

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -345,8 +345,8 @@ public class DefaultOcflObjectSessionTest {
         assertResourceContent("test", content, session.readContent(resourceId));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void throwExceptionOnRollbackWhenAutoVersioningNotUsed() {
+    @Test
+    public void allowRollbackWhenManualVersioningUsedButThereWasNotAnExistingMutableHead() {
         final var resourceId = "info:fedora/foo/bar";
         final var session = sessionFactory.newSession(resourceId);
         session.commitType(CommitType.UNVERSIONED);
@@ -359,6 +359,8 @@ public class DefaultOcflObjectSessionTest {
         assertResourceContent("test", content, session.readContent(resourceId));
 
         session.rollback();
+        
+        expectResourceNotFound(resourceId, session);
     }
 
     @Test(expected = IllegalStateException.class)


### PR DESCRIPTION
**Jira**: https://jira.lyrasis.org/browse/FCREPO-3130

## What this does?

Adds support for rolling back changes made in sessions that use auto-versioning. Rollback is implemented by removing the OCFL version that was created by the session.