### PR TITLE
added archivalGroupId to headers

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/ResourceHeaders.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/ResourceHeaders.java
@@ -43,6 +43,7 @@ public class ResourceHeaders {
 
     private final String id;
     private final String parent;
+    private final String archivalGroupId;
     private final String stateToken;
     private final String interactionModel;
     private final String mimeType;
@@ -71,6 +72,7 @@ public class ResourceHeaders {
     private ResourceHeaders(final Builder builder) {
         this(builder.id,
                 builder.parent,
+                builder.archivalGroupId,
                 builder.stateToken,
                 builder.interactionModel,
                 builder.mimeType,
@@ -91,6 +93,7 @@ public class ResourceHeaders {
 
     private ResourceHeaders(final String id,
                            final String parent,
+                           final String archivalGroupId,
                            final String stateToken,
                            final String interactionModel,
                            final String mimeType,
@@ -109,6 +112,7 @@ public class ResourceHeaders {
                            final String contentPath) {
         this.id = id;
         this.parent = parent;
+        this.archivalGroupId = archivalGroupId;
         this.stateToken = stateToken;
         this.interactionModel = interactionModel;
         this.mimeType = mimeType;
@@ -150,6 +154,13 @@ public class ResourceHeaders {
      */
     public String getParent() {
         return parent;
+    }
+
+    /**
+     * @return the fedora id of the archival group resource that contains this resource, or null
+     */
+    public String getArchivalGroupId() {
+        return archivalGroupId;
     }
 
     /**
@@ -275,6 +286,7 @@ public class ResourceHeaders {
         return "ResourceHeaders{" +
                 "id='" + id + '\'' +
                 ", parent='" + parent + '\'' +
+                ", archivalGroupId='" + archivalGroupId + '\'' +
                 ", stateToken='" + stateToken + '\'' +
                 ", interactionModel='" + interactionModel + '\'' +
                 ", mimeType='" + mimeType + '\'' +
@@ -308,6 +320,7 @@ public class ResourceHeaders {
                 deleted == that.deleted &&
                 Objects.equals(id, that.id) &&
                 Objects.equals(parent, that.parent) &&
+                Objects.equals(archivalGroupId, that.archivalGroupId) &&
                 Objects.equals(stateToken, that.stateToken) &&
                 Objects.equals(interactionModel, that.interactionModel) &&
                 Objects.equals(mimeType, that.mimeType) &&
@@ -325,7 +338,7 @@ public class ResourceHeaders {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, parent, stateToken,
+        return Objects.hash(id, parent, archivalGroupId, stateToken,
                 interactionModel, mimeType, filename,
                 contentSize, digests, externalUrl,
                 externalHandling, createdDate, createdBy,
@@ -341,6 +354,7 @@ public class ResourceHeaders {
 
         private String id;
         private String parent;
+        private String archivalGroupId;
         private String stateToken;
         private String interactionModel;
         private String mimeType;
@@ -365,6 +379,7 @@ public class ResourceHeaders {
         public Builder(final ResourceHeaders original) {
             this.id = original.getId();
             this.parent = original.getParent();
+            this.archivalGroupId = original.getArchivalGroupId();
             this.stateToken = original.getStateToken();
             this.interactionModel = original.getInteractionModel();
             this.mimeType = original.getMimeType();
@@ -390,6 +405,11 @@ public class ResourceHeaders {
 
         public Builder withParent(final String parent) {
             this.parent = parent;
+            return this;
+        }
+
+        public Builder withArchivalGroupId(final String archivalGroupId) {
+            this.archivalGroupId = archivalGroupId;
             return this;
         }
 

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -235,7 +235,7 @@ public class DefaultOcflObjectSessionTest {
         final var session = sessionFactory.newSession(agId);
 
         final var agContent = ag(agId, ROOT, "foo");
-        final var containerContent = container(containerId, agId, "bar");
+        final var containerContent = container(containerId, agId, agId, "bar");
         final var binaryContent = binary(binaryId, containerId, agId, "baz");
 
         write(session, agContent);
@@ -268,7 +268,7 @@ public class DefaultOcflObjectSessionTest {
         final var session = sessionFactory.newSession(agId);
 
         final var agContent = ag(agId, ROOT, "foo");
-        final var containerContent = container(containerId, agId, "bar");
+        final var containerContent = container(containerId, agId, agId, "bar");
         final var binaryContent = binary(binaryId, containerId, agId, "baz");
 
         write(session, agContent);
@@ -280,7 +280,7 @@ public class DefaultOcflObjectSessionTest {
         final var session2 = sessionFactory.newSession(agId);
 
         final var agContent2 = ag(agId, ROOT, "foo2");
-        final var containerContent2 = container(containerId, agId, "bar2");
+        final var containerContent2 = container(containerId, agId, agId, "bar2");
         final var deleteHeaders = ResourceHeaders.builder(binaryContent.getHeaders())
                 .withDeleted(true)
                 .withContentPath(null)
@@ -395,7 +395,7 @@ public class DefaultOcflObjectSessionTest {
         final var session = cachedSessionFactory.newSession(agId);
 
         final var agContent = ag(agId, ROOT, "foo");
-        final var containerContent = container(containerId, agId, "bar");
+        final var containerContent = container(containerId, agId, agId, "bar");
         final var binaryContent = binary(binaryId, containerId, agId, "baz");
 
         write(session, agContent);
@@ -1380,7 +1380,7 @@ public class DefaultOcflObjectSessionTest {
         session.commitType(CommitType.UNVERSIONED);
 
         final var agContent = ag(agId, ROOT, "foo");
-        final var containerContent = container(containerId, agId, "bar");
+        final var containerContent = container(containerId, agId, agId, "bar");
         final var binaryContent = binary(binaryId, containerId, "baz");
         final var binary2Content = binary(binary2Id, containerId, "boz");
 
@@ -1411,7 +1411,7 @@ public class DefaultOcflObjectSessionTest {
         final var session3 = sessionFactory.newSession(agId);
         session3.commitType(CommitType.UNVERSIONED);
 
-        final var containerContentV2 = container(containerId, agId, "bar - 2");
+        final var containerContentV2 = container(containerId, agId, agId, "bar - 2");
         final var binaryContentV2 = binary(binaryId, containerId, "baz - 2");
 
         write(session3, containerContentV2);
@@ -1429,7 +1429,7 @@ public class DefaultOcflObjectSessionTest {
         final var session4 = sessionFactory.newSession(agId);
         session4.commitType(CommitType.UNVERSIONED);
 
-        final var containerContentV3 = container(containerId, agId, "bar - 3");
+        final var containerContentV3 = container(containerId, agId, agId, "bar - 3");
 
         write(session4, containerContentV3);
 
@@ -1553,6 +1553,7 @@ public class DefaultOcflObjectSessionTest {
         headers.withInteractionModel(InteractionModel.NON_RDF.getUri());
         headers.withMimeType("text/plain");
         headers.withContentPath(PersistencePaths.nonRdfResource(rootResourceId, resourceId).getContentFilePath());
+        headers.withArchivalGroupId(rootResourceId);
         return new ResourceContent(stream(content), headers.build());
     }
 
@@ -1566,13 +1567,17 @@ public class DefaultOcflObjectSessionTest {
         return new ResourceContent(stream(content), headers.build());
     }
 
-    private ResourceContent container(final String resourceId, final String parentId, final String content) {
+    private ResourceContent container(final String resourceId,
+                                      final String parentId,
+                                      final String rootResourceId,
+                                      final String content) {
         final var headers = defaultHeaders(resourceId, parentId, content);
         headers.withObjectRoot(false);
         headers.withArchivalGroup(false);
         headers.withInteractionModel(InteractionModel.BASIC_CONTAINER.getUri());
         headers.withMimeType("text/turtle");
         headers.withContentPath(PersistencePaths.rdfResource(parentId, resourceId).getContentFilePath());
+        headers.withArchivalGroupId(rootResourceId);
         return new ResourceContent(stream(content), headers.build());
     }
 


### PR DESCRIPTION
**JIRA**: https://jira.lyrasis.org/browse/FCREPO-3123

## What this does?

Adds a new header to the resource headers, `archivalGroupId`. This header is to be set on all archival group part resources and it points to the AG that contains them.

This change is needed for the forthcoming resource locking PR, which is what the linked jira is for.