### PR TITLE
upgrade to ocfl-java 0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <dependency>
       <groupId>edu.wisc.library.ocfl</groupId>
       <artifactId>ocfl-java-core</artifactId>
-      <version>0.1.0</version>
+      <version>0.2.0</version>
       <exclusions>
         <exclusion>
           <groupId>com.github.ben-manes.caffeine</groupId>

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
-import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncatedNTupleConfig;
+import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.lang3.SystemUtils;
@@ -67,7 +67,7 @@ public class DefaultOcflObjectSessionFactoryTest {
                 LogicalPathMappers.percentEncodingWindowsMapper() : LogicalPathMappers.percentEncodingLinuxMapper();
 
         ocflRepo = new OcflRepositoryBuilder()
-                .layoutConfig(new HashedTruncatedNTupleConfig())
+                .defaultLayoutConfig(new HashedNTupleLayoutConfig())
                 .logicalPathMapper(logicalPathMapper)
                 .storage(FileSystemOcflStorage.builder().repositoryRoot(ocflRoot).build())
                 .workDir(ocflTemp)

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -27,7 +27,7 @@ import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import edu.wisc.library.ocfl.api.exception.FixityCheckException;
 import edu.wisc.library.ocfl.api.model.ObjectVersionId;
 import edu.wisc.library.ocfl.core.OcflRepositoryBuilder;
-import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedTruncatedNTupleConfig;
+import edu.wisc.library.ocfl.core.extension.storage.layout.config.HashedNTupleLayoutConfig;
 import edu.wisc.library.ocfl.core.path.mapper.LogicalPathMappers;
 import edu.wisc.library.ocfl.core.storage.filesystem.FileSystemOcflStorage;
 import org.apache.commons.codec.digest.DigestUtils;
@@ -103,7 +103,7 @@ public class DefaultOcflObjectSessionTest {
                 LogicalPathMappers.percentEncodingWindowsMapper() : LogicalPathMappers.percentEncodingLinuxMapper();
 
         ocflRepo = new OcflRepositoryBuilder()
-                .layoutConfig(new HashedTruncatedNTupleConfig())
+                .defaultLayoutConfig(new HashedNTupleLayoutConfig())
                 .logicalPathMapper(logicalPathMapper)
                 .storage(FileSystemOcflStorage.builder().repositoryRoot(ocflRoot).build())
                 .workDir(ocflTemp)


### PR DESCRIPTION
**Jira:** https://jira.lyrasis.org/browse/FCREPO-3590

Upgrades ocfl-java to the latest version.

A key difference in this version is that the storage layout extension definition is moved into the `extensions` directory. While the layout extension we're using has not been merged yet, it is unlikely that it'll need to be updated again.

This change does mean that the layout config in the storage root will no longer be read. Existing repositories with the storage layout in the old location are still usable, but `ocfl-java` will **not** write the storage layout to the new location for an existing repository. You either need to recreate the repository or write it manually.

To manually create it, write the following to `ocfl-root/extensions/0004-hashed-n-tuple-storage-layout/config.json`:

```json
{
  "digestAlgorithm" : "sha256",
  "tupleSize" : 3,
  "numberOfTuples" : 3,
  "shortObjectRoot" : false,
  "extensionName" : "0004-hashed-n-tuple-storage-layout"
}
```

