### PR TITLE
validate resource headers on write

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import edu.wisc.library.ocfl.api.MutableOcflRepository;
 import org.fcrepo.storage.ocfl.cache.Cache;
+import org.fcrepo.storage.ocfl.validation.DefaultHeadersValidator;
+import org.fcrepo.storage.ocfl.validation.HeadersValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +50,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
     private final String defaultVersionMessage;
     private final String defaultVersionUserName;
     private final String defaultVersionUserAddress;
+    private HeadersValidator headersValidator;
 
     private boolean closed = false;
 
@@ -69,6 +72,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
         this.defaultVersionMessage = defaultVersionMessage;
         this.defaultVersionUserName = defaultVersionUserName;
         this.defaultVersionUserAddress = defaultVersionUserAddress;
+        this.headersValidator = new DefaultHeadersValidator();
     }
 
     @Override
@@ -84,7 +88,8 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
                 headerReader,
                 headerWriter,
                 defaultCommitType,
-                headersCache
+                headersCache,
+                headersValidator
         );
 
         session.versionAuthor(defaultVersionUserName, defaultVersionUserAddress);
@@ -116,4 +121,12 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
         this.defaultCommitType = Objects.requireNonNull(defaultCommitType, "defaultCommitType cannot be null");
     }
 
+    /**
+     * Changes the headers validator implementation for TESTING purposes.
+     *
+     * @param headersValidator the validator to use
+     */
+    public void setHeadersValidator(final HeadersValidator headersValidator) {
+        this.headersValidator = headersValidator;
+    }
 }

--- a/src/main/java/org/fcrepo/storage/ocfl/exception/ValidationException.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/exception/ValidationException.java
@@ -60,7 +60,7 @@ public class ValidationException extends RuntimeException {
         return new ValidationException(ocflObjectId, null, problems);
     }
 
-    public ValidationException(final String ocflObjectId,
+    private ValidationException(final String ocflObjectId,
                                final String resourceId,
                                final Collection<String> problems) {
         this.ocflObjectId = ocflObjectId;

--- a/src/main/java/org/fcrepo/storage/ocfl/exception/ValidationException.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/exception/ValidationException.java
@@ -28,17 +28,43 @@ import java.util.Objects;
  */
 public class ValidationException extends RuntimeException {
 
+    private final String resourceId;
     private final String ocflObjectId;
     private final Collection<String> problems;
 
     private String message;
 
-    public ValidationException(final Collection<String> problems) {
-        this(null, problems);
+    /**
+     * @param problems the validation problems
+     * @return validation exception
+     */
+    public static ValidationException create(final Collection<String> problems) {
+        return new ValidationException(null, null, problems);
     }
 
-    public ValidationException(final String ocflObjectId, final Collection<String> problems) {
+    /**
+     * @param resourceId the Fedora resource id that is invalid
+     * @param problems the validation problems
+     * @return validation exception
+     */
+    public static ValidationException createForResource(final String resourceId, final Collection<String> problems) {
+        return new ValidationException(null, resourceId, problems);
+    }
+
+    /**
+     * @param ocflObjectId the ocfl object id that is invalid
+     * @param problems the validation problems
+     * @return validation exception
+     */
+    public static ValidationException createForObject(final String ocflObjectId, final Collection<String> problems) {
+        return new ValidationException(ocflObjectId, null, problems);
+    }
+
+    public ValidationException(final String ocflObjectId,
+                               final String resourceId,
+                               final Collection<String> problems) {
         this.ocflObjectId = ocflObjectId;
+        this.resourceId = resourceId;
         this.problems = Objects.requireNonNull(problems, "problems cannot be null");
     }
 
@@ -49,6 +75,10 @@ public class ValidationException extends RuntimeException {
 
             if (ocflObjectId != null) {
                 builder.append("OCFL object ").append(ocflObjectId).append(" is not a valid Fedora 6 object. ");
+            }
+
+            if (resourceId != null) {
+                builder.append("Resource ").append(resourceId).append(" is not a valid Fedora 6 resource. ");
             }
 
             builder.append("The following problems were identified:");

--- a/src/main/java/org/fcrepo/storage/ocfl/validation/Context.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/validation/Context.java
@@ -73,7 +73,7 @@ class Context {
      */
     public void throwValidationException() {
         if (!problems.isEmpty()) {
-            throw new ValidationException(ocflObjectId, problems);
+            throw ValidationException.createForObject(ocflObjectId, problems);
         }
     }
 

--- a/src/main/java/org/fcrepo/storage/ocfl/validation/DefaultHeadersValidator.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/validation/DefaultHeadersValidator.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.fcrepo.storage.ocfl.validation;
+
+import org.fcrepo.storage.ocfl.InteractionModel;
+import org.fcrepo.storage.ocfl.PersistencePaths;
+import org.fcrepo.storage.ocfl.ResourceHeaders;
+import org.fcrepo.storage.ocfl.ResourceHeadersVersion;
+import org.fcrepo.storage.ocfl.exception.ValidationException;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Headers validator that supports version 1.0 of the resource headers
+ *
+ * @author pwinckles
+ */
+public class DefaultHeadersValidator implements HeadersValidator {
+
+    private static final Set<String> VALID_EXT_HANDLING = Set.of("proxy", "redirect");
+
+    /**
+     * Validates resource headers. The root headers MUST have a valid id and this method MUST NOT
+     * be called without first validating it.
+     *
+     * @param paths the persistence paths for the resource, may be null
+     * @param headers the headers to validate, may not be null
+     * @param rootHeaders the headers for the resource at the root of the OCFL object, may not be null
+     * @throws ValidationException when problems are identified
+     */
+    @Override
+    public void validate(final PersistencePaths paths,
+                         final ResourceHeaders headers,
+                         final ResourceHeaders rootHeaders) {
+        Objects.requireNonNull(headers, "headers may not be null");
+        Objects.requireNonNull(rootHeaders, "rootHeaders may not be null");
+
+        final var context = new Context();
+
+        generalHeaderValidation(context, paths, headers, rootHeaders);
+        nonRdfHeaderValidation(context, headers);
+
+        if (!Objects.equals(headers.getId(), rootHeaders.getId())) {
+            ValidationUtil.requireValue(context, "objectRoot", false, headers.isObjectRoot());
+            ValidationUtil.requireValue(context, "archivalGroup", false, headers.isArchivalGroup());
+
+            if (rootHeaders.isArchivalGroup()) {
+                validateArchivalPartHeaders(context, headers, rootHeaders);
+            } else {
+                validateAtomicPartHeaders(context, headers);
+            }
+        } else {
+            validateRootHeaders(context, headers);
+        }
+
+        context.throwValidationException();
+    }
+
+    private void validateRootHeaders(final Context context, final ResourceHeaders headers) {
+        final var model = headers.getInteractionModel();
+
+        if (ValidationUtil.isModel(InteractionModel.ACL, model)
+                || ValidationUtil.isModel(InteractionModel.NON_RDF_DESCRIPTION, model)) {
+            context.problem("Invalid interaction model value: %s.", model);
+        }
+
+        ValidationUtil.requireValue(context, "objectRoot", true, headers.isObjectRoot());
+        ValidationUtil.requireValue(context, "archivalGroupId", null, headers.getArchivalGroupId());
+
+        if (headers.isArchivalGroup() && !ValidationUtil.isContainer(model)) {
+            context.problem("Archival Group has an invalid interaction model: %s", model);
+        }
+    }
+
+    private void generalHeaderValidation(final Context context,
+                                         final PersistencePaths paths,
+                                         final ResourceHeaders headers,
+                                         final ResourceHeaders rootHeaders) {
+        ValidationUtil.requireValue(context, "headersVersion",
+                ResourceHeadersVersion.V1_0, headers.getHeadersVersion());
+        ValidationUtil.validateId(context, "id", headers.getId());
+        ValidationUtil.validateId(context, "parent", headers.getParent());
+        ValidationUtil.validateIdRelationship(context, "parent", headers.getParent(),
+                "id", headers.getId());
+        ValidationUtil.validateIdRelationship(context, "rootId", rootHeaders.getId(),
+                "id", headers.getId());
+
+        ValidationUtil.requireNotNull(context, "stateToken", headers.getStateToken());
+        ValidationUtil.validateInteractionModel(context, headers.getInteractionModel());
+        ValidationUtil.requireNotNull(context, "createdDate", headers.getCreatedDate());
+        ValidationUtil.requireNotNull(context, "lastModifiedDate", headers.getLastModifiedDate());
+
+        final var contentExpected = ValidationUtil.contentExpected(headers);
+
+        if (paths != null && contentExpected) {
+            ValidationUtil.requireValue(context, "contentPath", paths.getContentFilePath(), headers.getContentPath());
+        }
+
+        if (rootHeaders.isDeleted()) {
+            ValidationUtil.requireValue(context, "deleted", rootHeaders.isDeleted(), headers.isDeleted());
+        }
+
+        // All resources that are not external or deleted must have content files
+        if (contentExpected) {
+            ValidationUtil.requireNotEmpty(context, "digests", headers.getDigests());
+        }
+
+        ValidationUtil.validateDigests(context, headers.getDigests());
+    }
+
+    private void nonRdfHeaderValidation(final Context context, final ResourceHeaders headers) {
+        if (!headers.isDeleted() && ValidationUtil.isModel(InteractionModel.NON_RDF, headers.getInteractionModel())) {
+            ValidationUtil.requireNotNull(context, "mimeType", headers.getMimeType());
+        }
+
+        if (headers.getExternalHandling() != null || headers.getExternalUrl() != null) {
+            ValidationUtil.requireNotNull(context, "externalUrl", headers.getExternalUrl());
+
+            if (headers.getExternalHandling() == null
+                    || !VALID_EXT_HANDLING.contains(headers.getExternalHandling())) {
+                context.problem("Must define property 'externalHandling' as one of %s", VALID_EXT_HANDLING);
+            }
+
+            ValidationUtil.requireValue(context, "interactionModel",
+                    InteractionModel.NON_RDF.getUri(), headers.getInteractionModel());
+        }
+    }
+
+    private void validateArchivalPartHeaders(final Context context,
+                                             final ResourceHeaders headers,
+                                             final ResourceHeaders rootHeaders) {
+        ValidationUtil.requireValue(context, "archivalGroupId", rootHeaders.getId(), headers.getArchivalGroupId());
+    }
+
+    private void validateAtomicPartHeaders(final Context context, final ResourceHeaders headers) {
+        final var model = headers.getInteractionModel();
+
+        if (!(ValidationUtil.isModel(InteractionModel.ACL, model)
+                || ValidationUtil.isModel(InteractionModel.NON_RDF_DESCRIPTION, model))) {
+            context.problem("Invalid interaction model %s." +
+                            " Atomic resources may only contain ACLs and non-RDF descriptions.", model);
+        } else if (headers.getParent() != null) {
+            if (ValidationUtil.isModel(InteractionModel.ACL, model)) {
+                ValidationUtil.requireValue(context, "id", headers.getParent() + "/" + PersistencePaths.FCR_ACL,
+                        headers.getId());
+            } else {
+                ValidationUtil.requireValue(context, "id", headers.getParent() + "/" + PersistencePaths.FCR_METADATA,
+                        headers.getId());
+            }
+        }
+
+        ValidationUtil.requireValue(context, "archivalGroupId", null, headers.getArchivalGroupId());
+    }
+
+}

--- a/src/main/java/org/fcrepo/storage/ocfl/validation/ObjectValidator.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/validation/ObjectValidator.java
@@ -57,6 +57,12 @@ public class ObjectValidator {
     private final ObjectReader headerReader;
     private final DefaultHeadersValidator headersValidator;
 
+    /**
+     * Creates a new object validator
+     *
+     * @param ocflRepo the ocfl repository
+     * @param headerReader the resourece header deserializer
+     */
     public ObjectValidator(final MutableOcflRepository ocflRepo,
                            final ObjectReader headerReader) {
         this.ocflRepo = Objects.requireNonNull(ocflRepo, "ocflRepo cannot be null");

--- a/src/main/java/org/fcrepo/storage/ocfl/validation/ObjectValidator.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/validation/ObjectValidator.java
@@ -55,13 +55,13 @@ public class ObjectValidator {
 
     private final MutableOcflRepository ocflRepo;
     private final ObjectReader headerReader;
-    private final HeadersValidator headersValidator;
+    private final DefaultHeadersValidator headersValidator;
 
     public ObjectValidator(final MutableOcflRepository ocflRepo,
                            final ObjectReader headerReader) {
         this.ocflRepo = Objects.requireNonNull(ocflRepo, "ocflRepo cannot be null");
         this.headerReader = Objects.requireNonNull(headerReader, "headerReader cannot be null");
-        this.headersValidator = new HeadersValidator();
+        this.headersValidator = new DefaultHeadersValidator();
     }
 
     /**

--- a/src/main/java/org/fcrepo/storage/ocfl/validation/ValidationUtil.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/validation/ValidationUtil.java
@@ -107,7 +107,7 @@ final class ValidationUtil {
                                 name, value, part);
                     } else {
                         for (var suffix : FORBIDDEN_SUFFIXES) {
-                            if (part.endsWith(suffix)) {
+                            if (part.endsWith(suffix) && !part.equals(suffix)) {
                                 context.problem("Invalid '%s' value '%s'. IDs may not contain parts that end with '%s'",
                                         name, value, suffix);
                                 break;

--- a/src/test/java/org/fcrepo/storage/ocfl/validation/DefaultHeadersValidatorTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/validation/DefaultHeadersValidatorTest.java
@@ -40,11 +40,11 @@ import static org.junit.Assert.fail;
 /**
  * @author pwinckles
  */
-public class HeadersValidatorTest {
+public class DefaultHeadersValidatorTest {
 
     private static final String ROOT_RESOURCE = "info:fedora";
 
-    private HeadersValidator validator;
+    private DefaultHeadersValidator validator;
 
     private String defaultId;
     private String defaultAclId;
@@ -54,7 +54,7 @@ public class HeadersValidatorTest {
 
     @Before
     public void setup() {
-        validator = new HeadersValidator();
+        validator = new DefaultHeadersValidator();
         defaultId = ResourceUtils.resourceId(UUID.randomUUID().toString());
         defaultAclId = ResourceUtils.toAclId(defaultId);
         defaultDescId = ResourceUtils.toDescId(defaultId);

--- a/src/test/java/org/fcrepo/storage/ocfl/validation/NoOpHeadersValidator.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/validation/NoOpHeadersValidator.java
@@ -20,26 +20,18 @@ package org.fcrepo.storage.ocfl.validation;
 
 import org.fcrepo.storage.ocfl.PersistencePaths;
 import org.fcrepo.storage.ocfl.ResourceHeaders;
-import org.fcrepo.storage.ocfl.exception.ValidationException;
 
 /**
- * Interface for validating resource headers
+ * A headers validator that does nothing. This is useful when wanting to intentionally create invalid objects for
+ * testing purposes.
  *
  * @author pwinckles
  */
-public interface HeadersValidator {
-
-    /**
-     * Validates resource headers. The root headers MUST have a valid id and this method MUST NOT
-     * be called without first validating it.
-     *
-     * @param paths the persistence paths for the resource, may be null
-     * @param headers the headers to validate, may not be null
-     * @param rootHeaders the headers for the resource at the root of the OCFL object, may not be null
-     * @throws ValidationException when problems are identified
-     */
-    void validate(final PersistencePaths paths,
-                  final ResourceHeaders headers,
-                  final ResourceHeaders rootHeaders);
-
+public class NoOpHeadersValidator implements HeadersValidator {
+    @Override
+    public void validate(final PersistencePaths paths,
+                         final ResourceHeaders headers,
+                         final ResourceHeaders rootHeaders) {
+        // no-op
+    }
 }

--- a/src/test/java/org/fcrepo/storage/ocfl/validation/ObjectValidatorTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/validation/ObjectValidatorTest.java
@@ -32,7 +32,6 @@ import org.apache.commons.lang3.SystemUtils;
 import org.fcrepo.storage.ocfl.CommitType;
 import org.fcrepo.storage.ocfl.DefaultOcflObjectSessionFactory;
 import org.fcrepo.storage.ocfl.InteractionModel;
-import org.fcrepo.storage.ocfl.OcflObjectSessionFactory;
 import org.fcrepo.storage.ocfl.PersistencePaths;
 import org.fcrepo.storage.ocfl.ResourceContent;
 import org.fcrepo.storage.ocfl.ResourceHeaders;
@@ -80,7 +79,7 @@ public class ObjectValidatorTest {
     private Path ocflRoot;
 
     private MutableOcflRepository ocflRepo;
-    private OcflObjectSessionFactory sessionFactory;
+    private DefaultOcflObjectSessionFactory sessionFactory;
     private ObjectMapper objectMapper;
 
     private ObjectValidator objectValidator;
@@ -117,6 +116,7 @@ public class ObjectValidatorTest {
                 objectMapper,
                 new NoOpCache<>(),
                 CommitType.NEW_VERSION, DEFAULT_MESSAGE, DEFAULT_USER, DEFAULT_ADDRESS);
+        sessionFactory.setHeadersValidator(new NoOpHeadersValidator());
 
         objectValidator = new ObjectValidator(ocflRepo, objectMapper.readerFor(ResourceHeaders.class));
 

--- a/src/test/java/org/fcrepo/storage/ocfl/validation/ValidationUtilTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/validation/ValidationUtilTest.java
@@ -146,6 +146,15 @@ public class ValidationUtilTest {
     }
 
     @Test
+    public void validateIdDoesNotFailWhenIllegalSuffixEntirePart() {
+        final var tmpl = ResourceUtils.resourceId("a/b/%s");
+        FORBIDDEN_SUFFIXES.forEach(part -> {
+            ValidationUtil.validateId(context, "id", String.format(tmpl, part));
+        });
+        context.throwValidationException();
+    }
+
+    @Test
     public void validateValidateId() {
         ValidationUtil.validateId(context, "id", ResourceUtils.resourceId("hello"));
         context.throwValidationException();


### PR DESCRIPTION
**Jira**: https://jira.lyrasis.org/browse/FCREPO-3606

## What this does

* Validates resource headers on write
* Fixes bug where resource id parts were incorrectly rejected if the entire part was equal to a forbidden suffix

## How to test

This is difficult to exercise in practice because headers should only ever fail validation if Fedora has a bug that causes it to produce invalid headers.