### PR TITLE
enforce fcr prefix restrictions

### DIFF
--- a/src/test/java/org/fcrepo/storage/ocfl/validation/ValidationUtilTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/validation/ValidationUtilTest.java
@@ -146,6 +146,34 @@ public class ValidationUtilTest {
     }
 
     @Test
+    public void validateIdFailWhenStartsWithFcrPrefix() {
+        ValidationUtil.validateId(context, "id", ResourceUtils.resourceId("a/fcr:tx"));
+        ValidationUtil.validateId(context, "id", ResourceUtils.resourceId("a/fcr:foo/b"));
+        ValidationUtil.validateId(context, "id", ResourceUtils.resourceId("fcr:foo:bar/a"));
+        ValidationUtil.validateId(context, "id", ResourceUtils.resourceId("afcr:tx"));
+        ValidationUtil.validateId(context, "id", ResourceUtils.resourceId("a/fcr:metadata"));
+        ValidationUtil.validateId(context, "id", ResourceUtils.resourceId("a/fcr:acl"));
+
+        failsWith(containsString("Invalid 'id' value 'info:fedora/a/fcr:tx'." +
+                        " IDs may not contain parts prefixed with 'fcr:'"),
+                containsString("Invalid 'id' value 'info:fedora/a/fcr:foo/b'." +
+                        " IDs may not contain parts prefixed with 'fcr:'"),
+                containsString("Invalid 'id' value 'info:fedora/fcr:foo:bar/a'." +
+                        " IDs may not contain parts prefixed with 'fcr:'"));
+    }
+
+    @Test
+    public void validateIdFailWhenFcrAclOrFcrMetadataNotFinalPart() {
+        ValidationUtil.validateId(context, "id", ResourceUtils.resourceId("a/fcr:metadata/b"));
+        ValidationUtil.validateId(context, "id", ResourceUtils.resourceId("a/fcr:acl/b"));
+
+        failsWith(containsString("Invalid 'id' value 'info:fedora/a/fcr:metadata/b'." +
+                        " IDs may not have a part following 'fcr:metadata'"),
+                containsString("Invalid 'id' value 'info:fedora/a/fcr:acl/b'." +
+                        " IDs may not have a part following 'fcr:acl'"));
+    }
+
+    @Test
     public void validateIdDoesNotFailWhenIllegalSuffixEntirePart() {
         final var tmpl = ResourceUtils.resourceId("a/b/%s");
         FORBIDDEN_SUFFIXES.forEach(part -> {


### PR DESCRIPTION
**Jira** https://jira.lyrasis.org/browse/FCREPO-3651

# What this does

* Resource IDs that contain the `fcr:` prefix that do not equal `fcr:acl` or `fcr:metdata` are rejected
* Resource IDs that contain `fcr:acl` or `fcr:metdata` but they are not the final part of the ID are rejected

# How to test

Outside of the unit tests, this could be tested by building Fedora with it and trying to side-load a resource that contains an ID that validates one of these restrictions.