### PR TITLE
Add support of unsafe ocfl writes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
     <source.plugin.version>3.0.1</source.plugin.version>
     <javadoc.plugin.version>3.2.0</javadoc.plugin.version>
-    <ocfl-java.version>1.0.3</ocfl-java.version>
+    <ocfl-java.version>1.1.0</ocfl-java.version>
   </properties>
 
   <scm>

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
@@ -121,7 +121,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
     }
 
     @Override
-    public void useUnsafeWrite(boolean useUnsafeWrite) {
+    public void useUnsafeWrite(final boolean useUnsafeWrite) {
         this.useUnsafeWrite = useUnsafeWrite;
     }
 

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
@@ -51,9 +51,22 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
     private final String defaultVersionUserName;
     private final String defaultVersionUserAddress;
     private HeadersValidator headersValidator;
+    private boolean useUnsafeWrite = false;
 
     private boolean closed = false;
 
+    /**
+     * Creates a new DefaultOcflObjectSessionFactory
+     *
+     * @param ocflRepo the ocfl repo
+     * @param stagingRoot the path to the directory to stage changes in
+     * @param objectMapper the object mapper used to serialize resource headers
+     * @param headersCache the cache to store deserialized headers in
+     * @param defaultCommitType specifies if commits should create new versions
+     * @param defaultVersionMessage the text to insert in the OCFL version message
+     * @param defaultVersionUserName the user name to insert in the OCFL version
+     * @param defaultVersionUserAddress the user address to insert in the OCFL version
+     */
     public DefaultOcflObjectSessionFactory(final MutableOcflRepository ocflRepo,
                                            final Path stagingRoot,
                                            final ObjectMapper objectMapper,
@@ -89,7 +102,8 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
                 headerWriter,
                 defaultCommitType,
                 headersCache,
-                headersValidator
+                headersValidator,
+                useUnsafeWrite
         );
 
         session.versionAuthor(defaultVersionUserName, defaultVersionUserAddress);
@@ -104,6 +118,11 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
             closed = true;
             ocflRepo.close();
         }
+    }
+
+    @Override
+    public void useUnsafeWrite(boolean useUnsafeWrite) {
+        this.useUnsafeWrite = useUnsafeWrite;
     }
 
     private void enforceOpen() {

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSessionFactory.java
@@ -38,4 +38,13 @@ public interface OcflObjectSessionFactory {
      */
     void close();
 
+    /**
+     * When unsafe writes are enabled, files are added to OCFL versions by providing the OCFL client with their
+     * digest. The client trusts that the digest is accurate and does not calculate the value for itself. This should
+     * increase performance, but will corrupt the object if the digest is incorrect.
+     *
+     * @param useUnsafeWrite true to use unsafe OCFL writes
+     */
+    void useUnsafeWrite(boolean useUnsafeWrite);
+
 }

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -102,7 +102,7 @@ public class DefaultOcflObjectSessionTest {
     private static final String DEFAULT_USER = "fedoraAdmin";
     private static final String DEFAULT_ADDRESS = "info:fedora/fedoraAdmin";
 
-    public DefaultOcflObjectSessionTest(boolean useUnsafeWrite) {
+    public DefaultOcflObjectSessionTest(final boolean useUnsafeWrite) {
         this.useUnsafeWrite = useUnsafeWrite;
     }
 

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -40,6 +40,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,6 +54,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -72,13 +75,20 @@ import static org.junit.Assert.fail;
 /**
  * @author pwinckles
  */
+@RunWith(Parameterized.class)
 public class DefaultOcflObjectSessionTest {
 
     @Rule
     public TemporaryFolder temp = TemporaryFolder.builder().assureDeletion().build();
 
+    @Parameterized.Parameters
+    public static Collection<Boolean> data() {
+        return List.of(false, true);
+    }
+
     private Path ocflRoot;
     private Path sessionStaging;
+    private boolean useUnsafeWrite;
 
     private MutableOcflRepository ocflRepo;
     private OcflObjectSessionFactory sessionFactory;
@@ -91,6 +101,10 @@ public class DefaultOcflObjectSessionTest {
     private static final String DEFAULT_MESSAGE = "F6 migration";
     private static final String DEFAULT_USER = "fedoraAdmin";
     private static final String DEFAULT_ADDRESS = "info:fedora/fedoraAdmin";
+
+    public DefaultOcflObjectSessionTest(boolean useUnsafeWrite) {
+        this.useUnsafeWrite = useUnsafeWrite;
+    }
 
     @Before
     public void setup() throws IOException {
@@ -118,6 +132,7 @@ public class DefaultOcflObjectSessionTest {
                 objectMapper,
                 new NoOpCache<>(),
                 CommitType.NEW_VERSION, DEFAULT_MESSAGE, DEFAULT_USER, DEFAULT_ADDRESS);
+        sessionFactory.useUnsafeWrite(useUnsafeWrite);
 
         cache = Caffeine.newBuilder().maximumSize(100).build();
 
@@ -126,6 +141,7 @@ public class DefaultOcflObjectSessionTest {
                 objectMapper,
                 new CaffeineCache<>(cache),
                 CommitType.NEW_VERSION, DEFAULT_MESSAGE, DEFAULT_USER, DEFAULT_ADDRESS);
+        cachedSessionFactory.useUnsafeWrite(useUnsafeWrite);
     }
 
     @Test
@@ -915,8 +931,8 @@ public class DefaultOcflObjectSessionTest {
         }
     }
 
-    @Test(expected = FixityCheckException.class)
-    public void failWhenProvidedDigestDoesNotMatchComputed() throws URISyntaxException {
+    @Test
+    public void failWhenProvidedDigestDoesNotMatchComputed() {
         final var resourceId = "info:fedora/foo";
         final var content = ResourceUtils.atomicBinary(resourceId, ROOT, "bar", headers -> {
             headers.withDigests(List.of(
@@ -927,7 +943,21 @@ public class DefaultOcflObjectSessionTest {
         final var session = sessionFactory.newSession(resourceId);
 
         write(session, content);
-        session.commit();
+
+        try {
+            session.commit();
+            if (useUnsafeWrite) {
+                // an exception should not be thrown when unsafe writes are used
+            } else {
+                fail("Commit should have thrown a FixityCheckException");
+            }
+        } catch (FixityCheckException e) {
+            if (!useUnsafeWrite) {
+                // this is expected
+            } else {
+                fail("Commit should not have thrown a FixityCheckException");
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3711

# What does this Pull Request do?

Adds an option for enabling unsafe OCFL writes. When this option is enabled, the OCFL client will not calculate a digest for files that are added to objects. This should be faster, but is less safe as the object will be corrupted if the digest is incorrect.

# How should this be tested?

There should be no noticeable difference in behavior.

# Interested parties
@fcrepo/committers
