### PR TITLE
add a root resource id cache

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactory.java
@@ -46,6 +46,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
     private final ObjectReader headerReader;
     private final ObjectWriter headerWriter;
     private final Cache<String, ResourceHeaders> headersCache;
+    private final Cache<String, String> rootIdCache;
     private CommitType defaultCommitType;
     private final String defaultVersionMessage;
     private final String defaultVersionUserName;
@@ -62,6 +63,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
      * @param stagingRoot the path to the directory to stage changes in
      * @param objectMapper the object mapper used to serialize resource headers
      * @param headersCache the cache to store deserialized headers in
+     * @param rootIdCache the cache that maps OCFL objects to the root resource id
      * @param defaultCommitType specifies if commits should create new versions
      * @param defaultVersionMessage the text to insert in the OCFL version message
      * @param defaultVersionUserName the user name to insert in the OCFL version
@@ -71,6 +73,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
                                            final Path stagingRoot,
                                            final ObjectMapper objectMapper,
                                            final Cache<String, ResourceHeaders> headersCache,
+                                           final Cache<String, String> rootIdCache,
                                            final CommitType defaultCommitType,
                                            final String defaultVersionMessage,
                                            final String defaultVersionUserName,
@@ -81,6 +84,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
                 .readerFor(ResourceHeaders.class);
         this.headerWriter = objectMapper.writerFor(ResourceHeaders.class);
         this.headersCache = headersCache;
+        this.rootIdCache = rootIdCache;
         this.defaultCommitType = Objects.requireNonNull(defaultCommitType, "defaultCommitType cannot be null");
         this.defaultVersionMessage = defaultVersionMessage;
         this.defaultVersionUserName = defaultVersionUserName;
@@ -102,6 +106,7 @@ public class DefaultOcflObjectSessionFactory implements OcflObjectSessionFactory
                 headerWriter,
                 defaultCommitType,
                 headersCache,
+                rootIdCache,
                 headersValidator,
                 useUnsafeWrite
         );

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionFactoryTest.java
@@ -82,6 +82,7 @@ public class DefaultOcflObjectSessionFactoryTest {
                 sessionStaging,
                 objectMapper,
                 new NoOpCache<>(),
+                new NoOpCache<>(),
                 CommitType.NEW_VERSION, DEFAULT_MESSAGE, DEFAULT_USER, DEFAULT_ADDRESS);
     }
 

--- a/src/test/java/org/fcrepo/storage/ocfl/validation/ObjectValidatorTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/validation/ObjectValidatorTest.java
@@ -115,6 +115,7 @@ public class ObjectValidatorTest {
                 sessionStaging,
                 objectMapper,
                 new NoOpCache<>(),
+                new NoOpCache<>(),
                 CommitType.NEW_VERSION, DEFAULT_MESSAGE, DEFAULT_USER, DEFAULT_ADDRESS);
         sessionFactory.setHeadersValidator(new NoOpHeadersValidator());
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3693

# What does this Pull Request do?

Adds a root resource id cache. This cache maps ocfl object ids to the object's root resource. This improves performance as it allows the resource header cache to be used to load an object's root resource headers when a new ocfl object session is created.

This addresses the gross performance degradation that Calvin reported in the migration utils. The problem was that a new session was created for every version of an object, requiring numerous unnecessary root resource header reads, which were slow because he is using a NAS.

# How should this be tested?

Migration utils should run faster.

# Interested parties

@fcrepo/committers
