### PR TITLE
upgrade ocfl-java to fix buffering bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
     <source.plugin.version>3.0.1</source.plugin.version>
     <javadoc.plugin.version>3.2.0</javadoc.plugin.version>
-    <ocfl-java.version>1.1.0</ocfl-java.version>
+    <ocfl-java.version>1.2.3</ocfl-java.version>
   </properties>
 
   <scm>

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -40,6 +40,7 @@ import org.fcrepo.storage.ocfl.validation.HeadersValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -574,7 +575,7 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
 
         if (Files.exists(stagingPath)) {
             try {
-                return Optional.of(Files.newInputStream(stagingPath));
+                return Optional.of(new BufferedInputStream(Files.newInputStream(stagingPath)));
             } catch (final IOException e) {
                 throw new UncheckedIOException(e);
             }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3758

# What does this Pull Request do?

Upgrades to the latest version of ocfl-java. The latest version adds buffering to all input streams, including streams that are returned via the api. This will resolve a couple of buffering related bugs in this code base as well, and hopefully make it much faster on systems running on a NAS.

# How should this be tested?

No functional changes

# Interested parties
@fcrepo/committers
