### PR TITLE
Do not write headers until commit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
     <source.plugin.version>3.0.1</source.plugin.version>
     <javadoc.plugin.version>3.2.0</javadoc.plugin.version>
-    <ocfl-java.version>1.2.3</ocfl-java.version>
+    <ocfl-java.version>1.3.1</ocfl-java.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3771

# What does this Pull Request do?

When creating binaries a binary resource and a binary description are created. Due to how the "touching" works, this was resulting in the binary's resources headers being serialized to disk multiple times. This change resolves the problem by deferring the serialization of any headers until the session is committed.

This improves write latency on systems with slow IO.

# How should this be tested?

Everything should work the same as before, and creating binary resources should be faster.

# Interested parties
@fcrepo/committers
