### PR TITLE
use memento created when touching related resources

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -659,17 +659,17 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
                 && !Objects.equals(rootResourceId(), headers.getId())
                 && !InteractionModel.ACL.getUri().equals(headers.getInteractionModel())) {
             LOG.debug("Touching AG {} after updating {}", rootResourceId(), headers.getId());
-            touchResource(rootResourceId(), headers.getLastModifiedDate());
+            touchResource(rootResourceId(), headers.getMementoCreatedDate());
         }
 
         if (InteractionModel.NON_RDF_DESCRIPTION.getUri().equals(headers.getInteractionModel())) {
             LOG.debug("Touching binary {} after updating {}", headers.getParent(), headers.getId());
-            touchResource(headers.getParent(), headers.getLastModifiedDate());
+            touchResource(headers.getParent(), headers.getMementoCreatedDate());
         } else if (InteractionModel.NON_RDF.getUri().equals(headers.getInteractionModel())) {
             final var descriptionId = headers.getId() + "/" + PersistencePaths.FCR_METADATA;
             LOG.debug("Touching binary description {} after updating {}", descriptionId, headers.getId());
             try {
-                touchResource(descriptionId, headers.getLastModifiedDate());
+                touchResource(descriptionId, headers.getMementoCreatedDate());
             } catch (final NotFoundException e) {
                 // Ignore this exception because it just means that the binary description hasn't been created yet
             }

--- a/src/test/java/org/fcrepo/storage/ocfl/ResourceUtils.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/ResourceUtils.java
@@ -313,6 +313,7 @@ public final class ResourceUtils {
         headers.withLastModifiedBy(DEFAULT_USER);
         final Instant now = Instant.now();
         headers.withLastModifiedDate(now);
+        headers.withMementoCreatedDate(now);
         headers.withStateToken(getStateToken(now));
         if (content != null) {
             headers.withContentSize((long) content.length());


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3786

# What does this Pull Request do?

Updates the code to use the memento created timestamp when touching related resources, resolving a bug where mementos were not being created on related resources when the last updated timestamp was the same as the existing memento created timestamp.

# How should this be tested?

1. Create a binary resource
2. Create a memento on the binary description
3. List the binary's mementos and see that a memento was created on it

# Interested parties

@fcrepo/committers
