### PR TITLE
Allow Invalidating Headers Cache

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -427,7 +427,7 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
     public void invalidateCache(final String resourceId) {
         listVersions(resourceId).stream()
             .map(version -> cacheKey(resourceId, version.getVersionNumber()))
-            .forEach(this::invalidateCache);
+            .forEach(headersCache::invalidate);
     }
 
     @Override

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -424,6 +424,11 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
     }
 
     @Override
+    public void invalidateCache(final String resourceId, final String versionNumber) {
+        headersCache.invalidate(cacheKey(resourceId, versionNumber));
+    }
+
+    @Override
     public void commitType(final CommitType commitType) {
         this.commitType = Objects.requireNonNull(commitType, "commitType cannot be null");
     }

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -425,9 +425,12 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
 
     @Override
     public void invalidateCache(final String resourceId) {
-        listVersions(resourceId).stream()
-            .map(version -> cacheKey(resourceId, version.getVersionNumber()))
-            .forEach(headersCache::invalidate);
+        try {
+            listVersions(resourceId).stream()
+                .map(version -> cacheKey(resourceId, version.getVersionNumber()))
+                .forEach(headersCache::invalidate);
+        } catch (NotFoundException ignored) {
+        }
     }
 
     @Override

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -424,8 +424,10 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
     }
 
     @Override
-    public void invalidateCache(final String resourceId, final String versionNumber) {
-        headersCache.invalidate(cacheKey(resourceId, versionNumber));
+    public void invalidateCache(final String resourceId) {
+        listVersions(resourceId).stream()
+            .map(version -> cacheKey(resourceId, version.getVersionNumber()))
+            .forEach(this::invalidateCache);
     }
 
     @Override

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -151,6 +151,14 @@ public interface OcflObjectSession extends AutoCloseable {
     void versionMessage(final String message);
 
     /**
+     * Invalidate the cache for a Fedora resource's headers
+     *
+     * @param resourceId the Fedora resource id to read
+     * @param versionNumber the version to read, or null for HEAD
+     */
+    void invalidateCache(final String resourceId, final String versionNumber);
+
+    /**
      * Sets the commit behavior -- create a new version or update the mutable HEAD.
      *
      * @param commitType the commit behavior

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -154,9 +154,8 @@ public interface OcflObjectSession extends AutoCloseable {
      * Invalidate the cache for a Fedora resource's headers
      *
      * @param resourceId the Fedora resource id to read
-     * @param versionNumber the version to read, or null for HEAD
      */
-    void invalidateCache(final String resourceId, final String versionNumber);
+    void invalidateCache(final String resourceId);
 
     /**
      * Sets the commit behavior -- create a new version or update the mutable HEAD.


### PR DESCRIPTION
For: https://fedora-repository.atlassian.net/browse/FCREPO-3553

# What does this Pull Request do?

Exposes cache invalidation operation for the resource headers

# Notes

I was initially going to do this for both the `rootIdCache` and `headersCache`, but opted on the side of doing only what we need. Could add it in here if wanted since it doesn't require much more work.

# Interested parties
@fcrepo/committers
