### PR TITLE
ignore empty v1's when validating

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/validation/ObjectValidator.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/validation/ObjectValidator.java
@@ -93,7 +93,9 @@ public class ObjectValidator {
 
             objDetails.getVersionMap().forEach((versionNum, versionDetails) -> {
                 try {
-                    validateVersion(versionNum, versionDetails);
+                    if (!isEmptyFirstVersion(versionNum, versionDetails)) {
+                        validateVersion(versionNum, versionDetails);
+                    }
                 } catch (ContinueException e) {
                     // Ignore -- this just means that a version is invalid
                     // but we still want to look at the other versions.
@@ -104,6 +106,19 @@ public class ObjectValidator {
             });
 
             context.throwValidationException();
+        }
+
+        /**
+         * When the mutable head extension is used and a new object is created, then the first version of the object
+         * is necessarily empty. This version should NOT be validated.
+         *
+         * @param versionNum the version number
+         * @param versionDetails the version's details
+         * @return true if it's an empty v1
+         */
+        private boolean isEmptyFirstVersion(final VersionNum versionNum,
+                                            final VersionDetails versionDetails) {
+            return versionNum.equals(VersionNum.V1) && versionDetails.getFiles().isEmpty();
         }
 
         private void validateVersion(final VersionNum versionNum, final VersionDetails versionDetails) {

--- a/src/test/java/org/fcrepo/storage/ocfl/validation/ObjectValidatorTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/validation/ObjectValidatorTest.java
@@ -125,6 +125,15 @@ public class ObjectValidatorTest {
     }
 
     @Test
+    public void validAtomicNonRdfResourceMutableHead() {
+        writeAndCommitMutable(defaultId,
+                ResourceUtils.atomicBinary(defaultId, ROOT_RESOURCE, "blah"),
+                ResourceUtils.atomicDesc(defaultDescId, defaultId, "blah desc"));
+
+        objectValidator.validate(defaultId, true);
+    }
+
+    @Test
     public void validAtomicRdfResource() {
         writeAndCommit(defaultId,
                 ResourceUtils.atomicContainer(defaultId, ROOT_RESOURCE, "blah"));
@@ -1033,6 +1042,15 @@ public class ObjectValidatorTest {
 
     private void writeAndCommit(final String id, final ResourceContent... content) {
         final var session = sessionFactory.newSession(id);
+        for (var c : content) {
+            session.writeResource(c.getHeaders(), c.getContentStream().orElse(null));
+        }
+        session.commit();
+    }
+
+    private void writeAndCommitMutable(final String id, final ResourceContent... content) {
+        final var session = sessionFactory.newSession(id);
+        session.commitType(CommitType.UNVERSIONED);
         for (var c : content) {
             session.writeResource(c.getHeaders(), c.getContentStream().orElse(null));
         }


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3822

# What does this Pull Request do?

Updates the validation code to ignore empty OCFL v1's when validating. Empty v1s are only created when the mutable head extension is used to create a new object, and Fedora should ignore them.

# How should this be tested?

1. Disable auto-versioning, `fcrepo.autoversioning.enabled`
2. Create a new resource
3. Restart Fedora with a rebuild, `fcrepo.rebuild.on.start`

Before this change it should fail. After this change it should validate.

# Interested parties

@fcrepo/committers
