### PR TITLE
Add storage relative path to ResourceHeaders

### DIFF
--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -989,6 +989,12 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
 
     private void moveStagedHeadersToCache(final String newVersionNum) {
         stagedHeaders.forEach((id, headers) -> {
+            final var pathpair = new PathPair(resolvePersistencePaths(headers).getHeaderFilePath(), null);
+            final var ocflFileDetails = getObjectVersionFile(pathpair, newVersionNum);
+            if (ocflFileDetails.isPresent()) {
+                final var path = ocflFileDetails.get().getStorageRelativePath();
+                headers.setStorageRelativePath(path);
+            }
             addToCache(id, newVersionNum, headers);
         });
         stagedHeaders.clear();

--- a/src/main/java/org/fcrepo/storage/ocfl/ResourceHeaders.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/ResourceHeaders.java
@@ -50,6 +50,8 @@ public class ResourceHeaders {
     private final boolean deleted;
     private final String contentPath;
     private final String headersVersion;
+    // A read-only field of the path of the resource relative to the storage root, if persisted.
+    private String storageRelativePath = null;
 
     public static Builder builder() {
         return new Builder();
@@ -291,6 +293,17 @@ public class ResourceHeaders {
         return headersVersion;
     }
 
+    /**
+     * @return the path of the resource relative to the storage root
+     */
+    public String getStorageRelativePath() {
+        return storageRelativePath;
+    }
+
+    protected void setStorageRelativePath(final String storageRelativePath) {
+        this.storageRelativePath = storageRelativePath;
+    }
+
     @Override
     public String toString() {
         return "ResourceHeaders{" +
@@ -315,6 +328,7 @@ public class ResourceHeaders {
                 ", deleted=" + deleted +
                 ", contentPath='" + contentPath + '\'' +
                 ", headersVersion='" + headersVersion + '\'' +
+                ", storageRelativePath='" + storageRelativePath + '\'' +
                 '}';
     }
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3935

# What does this Pull Request do?
Adds the `storageRelativePath` from the `OcflObjectVersionFile` to the `ResourceHeaders` so we can pass it up to Fedora.

This does not show the storage specific prefix. At this level we only have an `objectSession` and (I think) we would need the entire repository (`io.ocfl.api.OcflRepository`) to get the storage (`io.ocfl.core.storage.OcflStorage`) to get the [`objectRootPath()`](https://github.com/OCFL/ocfl-java/blob/main/ocfl-java-core/src/main/java/io/ocfl/core/storage/OcflStorage.java#L182-L188).

~This method also does not have a way to stop this new information from being loaded. Because of the existing functionality, it requires a second touch of the file which (I imagine) will have some performance impacts.~
Edit: I have moved things around to hopefully reduce duplication related to this processing.

# How should this be tested?



# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
