### PR TITLE
FCREPO-3957 - Support range requests at OCFL level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,7 +228,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>3.12.4</version>
+      <version>5.14.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <checkstyle.plugin.version>3.1.1</checkstyle.plugin.version>
     <source.plugin.version>3.0.1</source.plugin.version>
     <javadoc.plugin.version>3.2.0</javadoc.plugin.version>
-    <ocfl-java.version>2.1.0</ocfl-java.version>
+    <ocfl-java.version>2.2.1</ocfl-java.version>
     <sonatype.host>s01.oss.sonatype.org</sonatype.host>
   </properties>
 

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -41,14 +41,10 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.nio.file.StandardOpenOption;
 import java.security.DigestInputStream;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -373,12 +369,13 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
     }
 
     @Override
-    public ResourceContent readRange(String resourceId, long startPosition, long endPosition) {
+    public ResourceContent readRange(final String resourceId, final long startPosition, final long endPosition) {
         return readRange(resourceId, null, startPosition, endPosition);
     }
 
     @Override
-    public ResourceContent readRange(String resourceId, String versionNumber, long startPosition, long endPosition) {
+    public ResourceContent readRange(final String resourceId, final String versionNumber,
+                                     final long startPosition, final long endPosition) {
         ensureKnownRootResource();
 
         final var headers = readHeaders(resourceId, versionNumber);

--- a/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSession.java
@@ -22,6 +22,7 @@ import io.ocfl.api.model.VersionInfo;
 import io.ocfl.api.model.VersionNum;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.lang3.SystemUtils;
 import org.fcrepo.storage.ocfl.cache.Cache;
 import org.fcrepo.storage.ocfl.exception.InvalidContentException;
@@ -40,10 +41,14 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
 import java.security.DigestInputStream;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -368,6 +373,24 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
     }
 
     @Override
+    public ResourceContent readRange(String resourceId, long startPosition, long endPosition) {
+        return readRange(resourceId, null, startPosition, endPosition);
+    }
+
+    @Override
+    public ResourceContent readRange(String resourceId, String versionNumber, long startPosition, long endPosition) {
+        ensureKnownRootResource();
+
+        final var headers = readHeaders(resourceId, versionNumber);
+        Optional<InputStream> contentStream = Optional.empty();
+        if (headers.getContentPath() != null) {
+            contentStream = Optional.of(readRangeStream(encode(headers.getContentPath()), resourceId, versionNumber,
+                    startPosition, endPosition));
+        }
+        return new ResourceContent(contentStream, headers);
+    }
+
+    @Override
     public List<OcflVersionInfo> listVersions(final String resourceId) {
         final var headerPath = PersistencePaths.headerPath(rootResourceId(), resourceId);
 
@@ -608,6 +631,50 @@ public class DefaultOcflObjectSession implements OcflObjectSession {
     private Optional<InputStream> readFromOcflOptional(final PathPair path, final String versionNumber) {
         final var objectFile = getObjectVersionFile(path, versionNumber);
         return objectFile.map(OcflObjectVersionFile::getStream);
+    }
+
+    private InputStream readRangeStream(final PathPair path, final String resourceId, final String versionNumber,
+                                        final long startPosition, final long endPosition) {
+        return readRangeStreamOptional(path, versionNumber, startPosition, endPosition)
+                .orElseThrow(() -> notFoundException(path, resourceId));
+    }
+
+    private Optional<InputStream> readRangeStreamOptional(final PathPair path, final String versionNumber,
+                                                          final long startPosition, final long endPosition) {
+        if (isOpen() && deletePaths.contains(path)) {
+            return Optional.empty();
+        }
+
+        if (versionNumber != null) {
+            return readRangeFromOcflOptional(path, versionNumber, startPosition, endPosition);
+        }
+
+        return readRangeFromStaging(path, startPosition, endPosition)
+                .or(() -> readRangeFromOcflOptional(path, null, startPosition, endPosition));
+    }
+
+    private Optional<InputStream> readRangeFromStaging(final PathPair path,
+                                                       final long startPosition, final long endPosition) {
+        final var stagingPath = stagingPath(path);
+
+        if (Files.exists(stagingPath)) {
+            try {
+                final long length = endPosition + 1;
+                final var stream = new BoundedInputStream(Files.newInputStream(stagingPath), length);
+                stream.skip(startPosition);
+                return Optional.of(stream);
+            } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<InputStream> readRangeFromOcflOptional(final PathPair path, final String versionNumber,
+                                                            final long startPosition, final long endPosition) {
+        final var objectFile = getObjectVersionFile(path, versionNumber);
+        return objectFile.map(o -> o.getRange(startPosition, endPosition));
     }
 
     private Path stagingPath(final PathPair path) {

--- a/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
+++ b/src/main/java/org/fcrepo/storage/ocfl/OcflObjectSession.java
@@ -112,6 +112,29 @@ public interface OcflObjectSession extends AutoCloseable {
     ResourceContent readContent(final String resourceId, final String versionNumber);
 
     /**
+     * Reads a range of bytes of a resource's content.
+     *
+     * @param resourceId the Fedora resource id to read
+     * @param startPosition the position to start reading from, inclusive
+     * @param endPosition the position to stop reading at, inclusive
+     * @return the range of the resources content
+     */
+    ResourceContent readRange(final String resourceId,
+                              final long startPosition, final long endPosition);
+
+    /**
+     * Reads a range of bytes from a specific version of a resource's content.
+     *
+     * @param resourceId the Fedora resource id to read
+     * @param versionNumber the version to read, or null for HEAD
+     * @param startPosition the position to start reading from, inclusive
+     * @param endPosition the position to stop reading at, inclusive
+     * @return the range of the resources content
+     */
+    ResourceContent readRange(final String resourceId, final String versionNumber,
+                              final long startPosition, final long endPosition);
+
+    /**
      * List all of the versions associated to the resource in chrolological order.
      *
      * @param resourceId the Fedora resource id

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -1340,55 +1340,74 @@ public class DefaultOcflObjectSessionTest {
     @Test
     public void touchBinaryWhenDescUpdated() {
         final var resourceId = "info:fedora/foo";
-        final var content = ResourceUtils.atomicBinary(resourceId, ROOT, "foo");
-
         final var descId = "info:fedora/foo/fcr:metadata";
-        final var descContent = ResourceUtils.atomicDesc(descId, resourceId, "desc");
+        try (MockedStatic<Instant> mockInstant = Mockito.mockStatic(Instant.class, Mockito.CALLS_REAL_METHODS)) {
+            mockInstant.when(Instant::now).thenReturn(ORIGINAL_TIMESTAMP);
 
-        final var session = sessionFactory.newSession(resourceId);
+            final var content = ResourceUtils.atomicBinary(resourceId, ROOT, "foo");
+            final var descContent = ResourceUtils.atomicDesc(descId, resourceId, "desc");
 
-        write(session, content);
-        write(session, descContent);
-        session.commit();
+            final var session = sessionFactory.newSession(resourceId);
 
-        assertVersions(session.listVersions(resourceId), "v1");
-        assertVersions(session.listVersions(descId), "v1");
+            write(session, content);
+            write(session, descContent);
+            session.commit();
+        }
 
-        final var session2 = sessionFactory.newSession(resourceId);
-        final var descContent2 = ResourceUtils.atomicDesc(descId, resourceId, "desc2");
+        try (MockedStatic<Instant> mockInstant = Mockito.mockStatic(Instant.class, Mockito.CALLS_REAL_METHODS)) {
+            mockInstant.when(Instant::now).thenReturn(UPDATED_TIMESTAMP);
 
-        write(session2, descContent2);
-        session2.commit();
+            final var session = sessionFactory.newSession(resourceId);
 
-        assertVersions(session.listVersions(resourceId), "v1", "v2");
-        assertVersions(session.listVersions(descId), "v1", "v2");
+            assertVersions(session.listVersions(resourceId), "v1");
+            assertVersions(session.listVersions(descId), "v1");
+
+            final var session2 = sessionFactory.newSession(resourceId);
+            final var descContent2 = ResourceUtils.atomicDesc(descId, resourceId, "desc2");
+
+            write(session2, descContent2);
+            session2.commit();
+
+            assertVersions(session.listVersions(resourceId), "v1", "v2");
+            assertVersions(session.listVersions(descId), "v1", "v2");
+        }
     }
 
     @Test
     public void touchBinaryDescWhenBinaryUpdated() {
         final var resourceId = "info:fedora/foo";
-        final var content = ResourceUtils.atomicBinary(resourceId, ROOT, "foo");
-
         final var descId = "info:fedora/foo/fcr:metadata";
-        final var descContent = ResourceUtils.atomicDesc(descId, resourceId, "desc");
 
-        final var session = sessionFactory.newSession(resourceId);
+        try (MockedStatic<Instant> mockInstant = Mockito.mockStatic(Instant.class, Mockito.CALLS_REAL_METHODS)) {
+            mockInstant.when(Instant::now).thenReturn(ORIGINAL_TIMESTAMP);
 
-        write(session, content);
-        write(session, descContent);
-        session.commit();
+            final var content = ResourceUtils.atomicBinary(resourceId, ROOT, "foo");
+            final var descContent = ResourceUtils.atomicDesc(descId, resourceId, "desc");
 
-        assertVersions(session.listVersions(resourceId), "v1");
-        assertVersions(session.listVersions(descId), "v1");
+            final var session = sessionFactory.newSession(resourceId);
 
-        final var session2 = sessionFactory.newSession(resourceId);
-        final var content2 = ResourceUtils.atomicBinary(resourceId, ROOT, "bar");
+            write(session, content);
+            write(session, descContent);
+            session.commit();
+        }
 
-        write(session2, content2);
-        session2.commit();
+        try (MockedStatic<Instant> mockInstant = Mockito.mockStatic(Instant.class, Mockito.CALLS_REAL_METHODS)) {
+            mockInstant.when(Instant::now).thenReturn(UPDATED_TIMESTAMP);
 
-        assertVersions(session.listVersions(resourceId), "v1", "v2");
-        assertVersions(session.listVersions(descId), "v1", "v2");
+            final var session = sessionFactory.newSession(resourceId);
+
+            assertVersions(session.listVersions(resourceId), "v1");
+            assertVersions(session.listVersions(descId), "v1");
+
+            final var session2 = sessionFactory.newSession(resourceId);
+            final var content2 = ResourceUtils.atomicBinary(resourceId, ROOT, "bar");
+
+            write(session2, content2);
+            session2.commit();
+
+            assertVersions(session.listVersions(resourceId), "v1", "v2");
+            assertVersions(session.listVersions(descId), "v1", "v2");
+        }
     }
 
     @Test

--- a/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
+++ b/src/test/java/org/fcrepo/storage/ocfl/DefaultOcflObjectSessionTest.java
@@ -1559,7 +1559,7 @@ public class DefaultOcflObjectSessionTest {
         }
 
         // Update a subset of resources again -- mutable head
-        var timestamp3 = Instant.parse("2024-10-10T10:10:25.853500010Z");
+        final var timestamp3 = Instant.parse("2024-10-10T10:10:25.853500010Z");
         try (MockedStatic<Instant> mockInstant = Mockito.mockStatic(Instant.class, Mockito.CALLS_REAL_METHODS)) {
             mockInstant.when(Instant::now).thenReturn(timestamp3);
 
@@ -1579,7 +1579,7 @@ public class DefaultOcflObjectSessionTest {
         }
 
         // Commit mutable head
-        var timestamp4 = Instant.parse("2024-10-10T10:10:26.853500010Z");
+        final var timestamp4 = Instant.parse("2024-10-10T10:10:26.853500010Z");
         try (MockedStatic<Instant> mockInstant = Mockito.mockStatic(Instant.class, Mockito.CALLS_REAL_METHODS)) {
             mockInstant.when(Instant::now).thenReturn(timestamp4);
 


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3957?src=confmacro

# What does this Pull Request do?

* Updated to ocfl java 2.2.1.
* DefaultOcflObjectSession can now read a range of bytes from a file, either stored in OCFL or from staging.
* Updates to tests to prevent flapping, and updated mockito

# How should this be tested?

Currently just unit tests.

# Interested parties
@fcrepo/committers
