### PR TITLE
Update puppycrawl checkstyle version to match fcrepo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <release.plugin.version>3.1.1</release.plugin.version>
     <scm-provider-gitexe.plugin.version>2.1.0</scm-provider-gitexe.plugin.version>
     <checkstyle.plugin.version>3.6.0</checkstyle.plugin.version>
+    <puppycrawl.checkstyle.version>11.0.0</puppycrawl.checkstyle.version>
     <source.plugin.version>3.3.1</source.plugin.version>
     <javadoc.plugin.version>3.11.2</javadoc.plugin.version>
     <ocfl-java.version>2.2.1</ocfl-java.version>
@@ -50,7 +51,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.34</version>
+            <version>${puppycrawl.checkstyle.version}</version>
           </dependency>
         </dependencies>
         <configuration>


### PR DESCRIPTION
**The title of this pull-request should be a brief description of what the pull-request fixes/improves/changes. Ideally 50 characters or less.**
* * *
Relates to https://github.com/fcrepo/fcrepo-build-tools/pull/22

# What does this Pull Request do?
Fixes build error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-checkstyle-plugin:3.6.0:check (checkstyle) on project fcrepo-storage-ocfl: Failed during checkstyle configuration: cannot initialize module TreeWalker - cannot initialize module JavadocMethod - Property 'accessModifiers' does not exist, please check the documentation -> [Help 1]
```

# How should this be tested?
Build fails locally without this, and passes with it.

# Interested parties
@fcrepo/committers
