### PR TITLE
Fix build-tools dependency and snapshot publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 21
-          server-id: sonatype-nexus-snapshots
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           # https://github.com/actions/setup-java/issues/43

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
   <properties>
     <compiler.plugin.version>3.13.0</compiler.plugin.version>
-    <fcrepo-build-tools.version>7.0.0-SNAPSHOT</fcrepo-build-tools.version>
+    <fcrepo-build-tools.version>7.0.0</fcrepo-build-tools.version>
     <gpg.plugin.version>3.2.7</gpg.plugin.version>
     <jackson.version>2.18.2</jackson.version>
     <license.plugin.version>4.6</license.plugin.version>


### PR DESCRIPTION
## 1. `fcrepo-build-tools` pin cannot resolve

`pom.xml` pins:

```xml
<fcrepo-build-tools.version>7.0.0-SNAPSHOT</fcrepo-build-tools.version>
```

That artifact has never existed on Maven Central. `fcrepo-build-tools` released **7.0.0** on 2025-12-10, and its `main` has since moved to `7.1.0-SNAPSHOT`, so nothing will ever satisfy this pin.

Moved to the released **7.0.0**, which is what `fcrepo-parent` already uses.

There are no `src/` changes in `fcrepo-build-tools` between the 7.0.0 release and current `main`, so this is a no-op for the checkstyle and license rules applied here — it just makes the dependency resolvable.

## 2. This repo's snapshots have never published

```
https://central.sonatype.com/repository/maven-snapshots/org/fcrepo/fcrepo-storage-ocfl/maven-metadata.xml
-> 404
```

`central-publishing-maven-plugin` runs with `extensions=true`, so it takes over deployment and resolves credentials by `<publishingServerId>` — which is `central` ([pom.xml:179](https://github.com/fcrepo/fcrepo-storage-ocfl/blob/main/pom.xml#L179)). But the workflow had `setup-java` write a server id of `sonatype-nexus-snapshots`, so there is no matching server entry and the deploy has no credentials.

Both `build.yml` runs on `main` since the plugin was introduced show the same signature:

| Run | build (ubuntu) | build (windows) | deploy |
|---|---|---|---|
| [20107775711](https://github.com/fcrepo/fcrepo-storage-ocfl/actions/runs/20107775711) | success | success | **failure** |
| [20101987637](https://github.com/fcrepo/fcrepo-storage-ocfl/actions/runs/20101987637) | success | success | **failure** |

**Fix:** `server-id: central`.

This is the same fix applied in fcrepo/fcrepo-build-tools#24. After that merged, its snapshots started publishing immediately — `7.1.0-SNAPSHOT` is now live with `buildNumber: 1`, confirming the `OSSRH_USERNAME`/`OSSRH_TOKEN` org secrets already hold valid Central Portal tokens. No secret changes should be needed here.

## Not addressed

`<distributionManagement>` at [pom.xml:273](https://github.com/fcrepo/fcrepo-storage-ocfl/blob/main/pom.xml#L273) still contains `snapshotRepository` and `repository` entries that are dead config now that the plugin routes deployments itself, and they reference the same stale `sonatype-nexus-snapshots` id. I left them alone because the `<site>` entry in that block *is* still used by the site plugin, so it can't simply be deleted wholesale. Worth a follow-up.

## Testing

`mvn -B clean install -DskipTests` passes locally on this branch, with `checkstyle:check` and `license:check` both executing against the released 7.0.0. The deploy path can only be exercised on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
